### PR TITLE
Move agent-operational notes into dotfiles-repo skill

### DIFF
--- a/.agents/skills/dotfiles-repo/SKILL.md
+++ b/.agents/skills/dotfiles-repo/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: dotfiles-repo
+description: Use when working in the bare git dotfiles repo at ~/.dotfiles (worktree $HOME, accessed via the `dotfiles` alias / dotfiles-shell). Covers the inverse-allowlist .gitignore (`*` plus `!.agents/**`) and why `git add` warns on tracked files, the pre-commit identity hook requiring ajilty <github@ajilty.com> (do not --no-verify or --author=), `dotfiles pull` (rebase --autostash) conflict recovery including autostash-pop vs replay conflicts and the `update-index --refresh` gotcha, blocklist bootstrap on fresh machines, commit-message conventions (-F file, Co-Authored-By trailer), and the don'ts (no `git init` under $HOME, no force-pushing the public remote).
+---
+
+# dotfiles-repo
+
+Operational notes for LLM agents working in the ajilty dotfiles repo. Read this *before* poking at git state — the conventions here are non-obvious and a few will look like bugs if you don't know them.
+
+## Overview
+
+This skill applies when the working tree is `$HOME` and git operations target the bare repo at `~/.dotfiles/`. Every git invocation must point at both — the `dotfiles` shell alias handles this. The `.gitignore` is an inverse allowlist, identity is enforced by a pre-commit hook, and `dotfiles pull` is a rebase with autostash that can leave the repo mid-rebase. Each of these surprises has a documented resolution path below.
+
+## Checklist
+
+- Always use the `dotfiles` alias (or `dotfiles-shell`), never plain `git`.
+- For *new* files use `dotfiles add -f <path>`; for *tracked* files prefer `dotfiles add -u <path>` to suppress the "paths are ignored" warning.
+- Never `--no-verify`, never `--author=`, never `GIT_AUTHOR_*` — fix the includeIf instead.
+- Commit multi-line messages via `dotfiles commit -F <file>`; end LLM-assisted commits with the `Co-Authored-By:` trailer.
+
+## Repo shape
+
+This is a **bare git repo** at `~/.dotfiles/` with `$HOME` as the work tree. There is no `.git` directory in `~`. Every command must specify both:
+
+```bash
+git --git-dir=$HOME/.dotfiles --work-tree=$HOME <subcommand>
+```
+
+The `dotfiles` shell alias expands to exactly that. `~/.zshrc` defines it; in non-interactive contexts (where aliases don't expand) you must spell it out, or use `dotfiles-shell` which exports `GIT_DIR` and `GIT_WORK_TREE` for the rest of the shell.
+
+Useful aliases (defined in `~/.zshrc` / `~/.config/shell/`):
+- `dotfiles` — the bare-repo git wrapper
+- `dotfiles-tracked` — `git ls-tree -r master --name-only`
+- `dotfiles-update` — `dotfiles pull; zinit update --all`
+- `dotfiles status` — passthrough to `git status` against the bare repo
+
+## Gitignore mechanics (the #1 source of agent confusion)
+
+`.gitignore` uses an **inverse-allowlist pattern**:
+
+```
+*                # ignore everything
+!.agents/        # ...except the agent skills tree
+!.agents/**
+.agents/**/.DS_Store      # but re-ignore cruft inside it
+.agents/**/__pycache__/
+```
+
+Three consequences you will hit:
+
+1. **`git add` warns "paths are ignored" even for already-tracked files.** Because `*` matches everything, files like `.claude/settings.json` and `.config/ghostty/config.ghostty` look ignored to git's add-warning system *even though they're tracked*. Use one of:
+   - `dotfiles add -u <path>` — only updates already-tracked files, no warning.
+   - `dotfiles add -f <path>` — force-add, needed when adding a *new* file in an ignored directory.
+2. **Global `~/.config/git/ignore` is short-circuited inside this repo.** The repo-level `*` matches before git consults the global file. So a file like `__pycache__/foo.pyc` is *not* filtered by your global ignore once it lands under `.agents/` — the `!.agents/**` allowlist re-includes it. Cruft filters under `.agents/` must live in this repo's `.gitignore`, not the global file.
+3. **Any new file needs `-f` (or an explicit `!` rule).** Not just top-level — also new files inside already-tracked subtrees like `.ssh/config.d/`, `.claude/`, `.config/...`. `git status` will silently omit them until you force-add. Pattern: `dotfiles add -f .ssh/config.d/<newfile>`. README.md, AGENTS.md, etc. are tracked because they were force-added once.
+
+## Identity is enforced by a pre-commit hook
+
+`core.hooksPath = ~/.dotfiles-hooks` (set in `.config/git/dotfiles.config`, included via `[includeIf "gitdir:~/.dotfiles/"]` in `~/.config/git/config`). The `pre-commit` hook refuses any commit whose author or committer isn't `ajilty <github@ajilty.com>`.
+
+- **Don't `--no-verify`.** If the hook trips, the includeIf isn't matching — usually because `GIT_DIR` is unset or the user-level git config isn't loaded. Diagnose with `dotfiles config --show-origin user.email`.
+- **Don't pass `--author=` or set `GIT_AUTHOR_*` env vars** to "fix" identity at commit time. Fix the include block instead.
+
+## `dotfiles pull` can leave merge state
+
+`dotfiles pull` is `git pull --rebase --autostash` (`pull.rebase=true`, `rebase.autostash=true` are set per-repo). Two flavors of conflict are possible and they look similar but behave differently:
+
+- **Autostash-pop conflict** — the rebase finished, but reapplying the pre-pull dirty worktree conflicts. No active rebase metadata in `.dotfiles/rebase-merge/`.
+- **Real rebase replay conflict** — a local commit replayed onto the fetched tip conflicts. `.dotfiles/rebase-merge/` exists with `msgnum`/`end`/`onto`/`orig-head`/`stopped-sha` and `git branch` reports `(no branch, rebasing master)`.
+
+While any path is `UU`/`DU`/`UD`, **git refuses every commit, including unrelated ones**. Resolution:
+
+1. Inspect: `dotfiles status`, `cat .dotfiles/rebase-merge/{stopped-sha,message}` if present, and `git show <stopped-sha>` to see what the replay was trying to apply.
+2. Resolve each path. `add -f <file>` for modify-modify; `dotfiles rm -f <file>` to accept upstream's deletion (e.g. when upstream restructured — **always check whether content moved before assuming data loss**: `git grep <keyword> <upstream-tip> -- <related-dir>/`).
+3. Continue: `dotfiles rebase --continue` (use `-c core.editor=true` from non-interactive contexts to skip the editor prompt).
+
+**Gotcha — `rebase --continue` refuses with "you must edit all merge conflicts" even when nothing is unmerged.** Check `git update-index --refresh` output — if it lists an unrelated path as `needs update` (commonly `.claude/settings.json`), the dirty unstaged file is blocking the next commit step. Park it (`cp` it aside, `dotfiles checkout -- <file>`, continue rebase, restore the copy) and retry.
+
+**Gotcha — stray top-level `MERGE_MSG` from a prior failed pull.** It can confuse diagnostics (looks like an active merge), but it's only a leftover. Safe to `rm` if there's no `MERGE_HEAD` next to it and `.dotfiles/rebase-merge/` has its own `message`.
+
+## Content guard (blocklist) needs bootstrap per machine
+
+The `pre-commit` hook also scans the staged diff against a private blocklist fetched from a gist. On a fresh machine you'll see `WARN: dotfiles blocklist not initialized` — the commit still goes through (warn, not block), but the content scan is skipped.
+
+One-time setup on each new machine:
+
+```bash
+mkdir -p ~/.local/config/dotfiles
+echo "<private-gist-id>" > ~/.local/config/dotfiles/gist-id
+chmod 600 ~/.local/config/dotfiles/gist-id
+dotfiles-blocklist-sync
+```
+
+The gist must contain a file literally named `dotfiles-blocklist.txt`. After 30 days the local copy is considered stale (warns but still scans); re-run `dotfiles-blocklist-sync` to refresh.
+
+## Commit messages
+
+Pre-commit doesn't block on message content, but the hook runs `set -euo pipefail`, so commit via `-F <file>` (heredoc into a temp file) for multi-line messages — inline `$(cat <<'EOF' ... EOF)` heredocs interact badly with the wrapper alias in some shells.
+
+```bash
+dotfiles commit -F /tmp/msg.txt
+```
+
+End the message with the standard co-author trailer when an LLM contributed:
+
+```
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+## What lives where
+
+- `~/.gitignore` — repo-level ignores (the inverse-allowlist).
+- `~/.config/git/ignore` — global ignores (consulted only when no repo-level rule matches; tracked in this repo so it deploys to every machine).
+- `~/.config/git/dotfiles.config` — per-repo overrides (hooksPath + identity), included via `[includeIf "gitdir:~/.dotfiles/"]`.
+- `~/.dotfiles-hooks/` — the hooks dir referenced by the includeIf above.
+- `~/.agents/skills/` — vendored agent skills tree, intentionally tracked despite the global `*` ignore. New skills installed via `skills add` show up in `git status` automatically.
+- `~/.claude/settings.json` — Claude Code user settings (tracked).
+- `~/.claude/settings.local.json` — local-only overrides (gitignored globally via `**/.claude/settings.local.json` in `~/.config/git/ignore`).
+
+## Anti-patterns
+
+- Don't `git init` anywhere under `~`. Subdirectories under `$HOME` are part of the dotfiles work tree.
+- Don't push without confirming with the user. The remote is public.
+- Don't commit `.agents/.claude/`, `.agents/**/.DS_Store`, or `.agents/**/__pycache__/` — they're filtered by re-ignore rules but can still be force-added by accident.
+- Don't trust `git status` from a subdirectory unless you've used the `dotfiles` alias or set `GIT_DIR`/`GIT_WORK_TREE`. Plain `git status` will look for a `.git` and find nothing useful.

--- a/.agents/skills/dotfiles-repo/SKILL.md
+++ b/.agents/skills/dotfiles-repo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotfiles-repo
-description: Use when working in the bare git dotfiles repo at ~/.dotfiles (worktree $HOME, accessed via the `dotfiles` alias / dotfiles-shell). Covers the inverse-allowlist .gitignore (`*` plus `!.agents/**`) and why `git add` warns on tracked files, the pre-commit identity hook requiring ajilty <github@ajilty.com> (do not --no-verify or --author=), `dotfiles pull` (rebase --autostash) conflict recovery including autostash-pop vs replay conflicts and the `update-index --refresh` gotcha, blocklist bootstrap on fresh machines, commit-message conventions (-F file, Co-Authored-By trailer), and the don'ts (no `git init` under $HOME, no force-pushing the public remote).
+description: Use when working in the ajilty dotfiles bare git repo at ~/.dotfiles (worktree $HOME, `dotfiles` alias / dotfiles-shell). Triggers include `dotfiles add` warning paths-are-ignored on tracked files, the pre-commit hook rejecting commits whose author is not ajilty (github@ajilty.com), `dotfiles pull` leaving UU/DU paths or mid-rebase --autostash state with `.dotfiles/rebase-merge/`, "WARN dotfiles blocklist not initialized" on a fresh machine, or unfamiliarity with the inverse-allowlist .gitignore pattern (`*` plus `!.agents/**`) and why `git add` complains about already-tracked files.
 ---
 
 # dotfiles-repo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,109 +1,11 @@
 # AGENTS.md
 
-Operational notes for LLM agents working in this dotfiles repo. Read this *before* poking at git state — the conventions here are non-obvious and a few will look like bugs if you don't know them.
+Operational notes for this dotfiles repo have moved to the `dotfiles-repo` skill at [`.agents/skills/dotfiles-repo/SKILL.md`](.agents/skills/dotfiles-repo/SKILL.md). Agents with skill auto-discovery (Claude Code, Codex, Gemini CLI, Copilot CLI) load it on demand; the description triggers on bare-repo cues, the `dotfiles` alias, inverse-allowlist `.gitignore`, the `ajilty <github@ajilty.com>` pre-commit identity hook, and `dotfiles pull` rebase/autostash conflicts.
 
-## Repo shape
+Quick digest for tools that auto-load `AGENTS.md` but don't read skills:
 
-This is a **bare git repo** at `~/.dotfiles/` with `$HOME` as the work tree. There is no `.git` directory in `~`. Every command must specify both:
-
-```bash
-git --git-dir=$HOME/.dotfiles --work-tree=$HOME <subcommand>
-```
-
-The `dotfiles` shell alias expands to exactly that. `~/.zshrc` defines it; in non-interactive contexts (where aliases don't expand) you must spell it out, or use `dotfiles-shell` which exports `GIT_DIR` and `GIT_WORK_TREE` for the rest of the shell.
-
-Useful aliases (defined in `~/.zshrc` / `~/.config/shell/`):
-- `dotfiles` — the bare-repo git wrapper
-- `dotfiles-tracked` — `git ls-tree -r master --name-only`
-- `dotfiles-update` — `dotfiles pull; zinit update --all`
-- `dotfiles status` — passthrough to `git status` against the bare repo
-
-## Gitignore mechanics (the #1 source of agent confusion)
-
-`.gitignore` uses an **inverse-allowlist pattern**:
-
-```
-*                # ignore everything
-!.agents/        # ...except the agent skills tree
-!.agents/**
-.agents/**/.DS_Store      # but re-ignore cruft inside it
-.agents/**/__pycache__/
-```
-
-Three consequences you will hit:
-
-1. **`git add` warns "paths are ignored" even for already-tracked files.** Because `*` matches everything, files like `.claude/settings.json` and `.config/ghostty/config.ghostty` look ignored to git's add-warning system *even though they're tracked*. Use one of:
-   - `dotfiles add -u <path>` — only updates already-tracked files, no warning.
-   - `dotfiles add -f <path>` — force-add, needed when adding a *new* file in an ignored directory.
-2. **Global `~/.config/git/ignore` is short-circuited inside this repo.** The repo-level `*` matches before git consults the global file. So a file like `__pycache__/foo.pyc` is *not* filtered by your global ignore once it lands under `.agents/` — the `!.agents/**` allowlist re-includes it. Cruft filters under `.agents/` must live in this repo's `.gitignore`, not the global file.
-3. **Any new file needs `-f` (or an explicit `!` rule).** Not just top-level — also new files inside already-tracked subtrees like `.ssh/config.d/`, `.claude/`, `.config/...`. `git status` will silently omit them until you force-add. Pattern: `dotfiles add -f .ssh/config.d/<newfile>`. README.md, AGENTS.md, etc. are tracked because they were force-added once.
-
-## Identity is enforced by a pre-commit hook
-
-`core.hooksPath = ~/.dotfiles-hooks` (set in `.config/git/dotfiles.config`, included via `[includeIf "gitdir:~/.dotfiles/"]` in `~/.config/git/config`). The `pre-commit` hook refuses any commit whose author or committer isn't `ajilty <github@ajilty.com>`.
-
-- **Don't `--no-verify`.** If the hook trips, the includeIf isn't matching — usually because `GIT_DIR` is unset or the user-level git config isn't loaded. Diagnose with `dotfiles config --show-origin user.email`.
-- **Don't pass `--author=` or set `GIT_AUTHOR_*` env vars** to "fix" identity at commit time. Fix the include block instead.
-
-## `dotfiles pull` can leave merge state
-
-`dotfiles pull` is `git pull --rebase --autostash` (`pull.rebase=true`, `rebase.autostash=true` are set per-repo). Two flavors of conflict are possible and they look similar but behave differently:
-
-- **Autostash-pop conflict** — the rebase finished, but reapplying the pre-pull dirty worktree conflicts. No active rebase metadata in `.dotfiles/rebase-merge/`.
-- **Real rebase replay conflict** — a local commit replayed onto the fetched tip conflicts. `.dotfiles/rebase-merge/` exists with `msgnum`/`end`/`onto`/`orig-head`/`stopped-sha` and `git branch` reports `(no branch, rebasing master)`.
-
-While any path is `UU`/`DU`/`UD`, **git refuses every commit, including unrelated ones**. Resolution:
-
-1. Inspect: `dotfiles status`, `cat .dotfiles/rebase-merge/{stopped-sha,message}` if present, and `git show <stopped-sha>` to see what the replay was trying to apply.
-2. Resolve each path. `add -f <file>` for modify-modify; `dotfiles rm -f <file>` to accept upstream's deletion (e.g. when upstream restructured — **always check whether content moved before assuming data loss**: `git grep <keyword> <upstream-tip> -- <related-dir>/`).
-3. Continue: `dotfiles rebase --continue` (use `-c core.editor=true` from non-interactive contexts to skip the editor prompt).
-
-**Gotcha — `rebase --continue` refuses with "you must edit all merge conflicts" even when nothing is unmerged.** Check `git update-index --refresh` output — if it lists an unrelated path as `needs update` (commonly `.claude/settings.json`), the dirty unstaged file is blocking the next commit step. Park it (`cp` it aside, `dotfiles checkout -- <file>`, continue rebase, restore the copy) and retry.
-
-**Gotcha — stray top-level `MERGE_MSG` from a prior failed pull.** It can confuse diagnostics (looks like an active merge), but it's only a leftover. Safe to `rm` if there's no `MERGE_HEAD` next to it and `.dotfiles/rebase-merge/` has its own `message`.
-
-## Content guard (blocklist) needs bootstrap per machine
-
-The `pre-commit` hook also scans the staged diff against a private blocklist fetched from a gist. On a fresh machine you'll see `WARN: dotfiles blocklist not initialized` — the commit still goes through (warn, not block), but the content scan is skipped.
-
-One-time setup on each new machine:
-
-```bash
-mkdir -p ~/.local/config/dotfiles
-echo "<private-gist-id>" > ~/.local/config/dotfiles/gist-id
-chmod 600 ~/.local/config/dotfiles/gist-id
-dotfiles-blocklist-sync
-```
-
-The gist must contain a file literally named `dotfiles-blocklist.txt`. After 30 days the local copy is considered stale (warns but still scans); re-run `dotfiles-blocklist-sync` to refresh.
-
-## Commit messages
-
-Pre-commit doesn't block on message content, but the hook runs `set -euo pipefail`, so commit via `-F <file>` (heredoc into a temp file) for multi-line messages — inline `$(cat <<'EOF' ... EOF)` heredocs interact badly with the wrapper alias in some shells.
-
-```bash
-dotfiles commit -F /tmp/msg.txt
-```
-
-End the message with the standard co-author trailer when an LLM contributed:
-
-```
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
-```
-
-## What lives where
-
-- `~/.gitignore` — repo-level ignores (the inverse-allowlist).
-- `~/.config/git/ignore` — global ignores (consulted only when no repo-level rule matches; tracked in this repo so it deploys to every machine).
-- `~/.config/git/dotfiles.config` — per-repo overrides (hooksPath + identity), included via `[includeIf "gitdir:~/.dotfiles/"]`.
-- `~/.dotfiles-hooks/` — the hooks dir referenced by the includeIf above.
-- `~/.agents/skills/` — vendored agent skills tree, intentionally tracked despite the global `*` ignore. New skills installed via `skills add` show up in `git status` automatically.
-- `~/.claude/settings.json` — Claude Code user settings (tracked).
-- `~/.claude/settings.local.json` — local-only overrides (gitignored globally via `**/.claude/settings.local.json` in `~/.config/git/ignore`).
-
-## Don'ts
-
-- Don't `git init` anywhere under `~`. Subdirectories under `$HOME` are part of the dotfiles work tree.
-- Don't push without confirming with the user. The remote is public.
-- Don't commit `.agents/.claude/`, `.agents/**/.DS_Store`, or `.agents/**/__pycache__/` — they're filtered by re-ignore rules but can still be force-added by accident.
-- Don't trust `git status` from a subdirectory unless you've used the `dotfiles` alias or set `GIT_DIR`/`GIT_WORK_TREE`. Plain `git status` will look for a `.git` and find nothing useful.
+- Bare repo at `~/.dotfiles`, worktree `$HOME`. Use the `dotfiles` alias, never plain `git`.
+- `.gitignore` is inverse-allowlist (`*` + `!.agents/**`): `dotfiles add -u` for tracked files, `dotfiles add -f` for new ones outside `.agents/`.
+- Pre-commit hook enforces author `ajilty <github@ajilty.com>`; never `--no-verify` or `--author=`.
+- `dotfiles pull` is `git pull --rebase --autostash`; see the skill for conflict recovery (autostash-pop vs replay, the `update-index --refresh` gotcha).
+- Multi-line commit messages: `dotfiles commit -F <file>`. Public remote — don't push without user confirmation.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Dotfiles
 
-> **Working with LLM agents in this repo?** See [AGENTS.md](AGENTS.md) for the
-> non-obvious mechanics (bare-repo layout, inverse-allowlist `.gitignore`,
-> pre-commit identity guard, autostash conflict handling).
+> **Working with LLM agents in this repo?** Operational mechanics live in the
+> `dotfiles-repo` skill at [.agents/skills/dotfiles-repo/SKILL.md](.agents/skills/dotfiles-repo/SKILL.md)
+> (bare-repo layout, inverse-allowlist `.gitignore`, pre-commit identity guard, autostash conflict handling).
+> A short digest also remains in [AGENTS.md](AGENTS.md) for non-skill-aware tools.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

Moves the agent-operational content out of `AGENTS.md` (109 lines) into a new skill at `.agents/skills/dotfiles-repo/SKILL.md`, so every agent CLI that honors the `~/.agents/skills/` convention (Claude Code via `~/.claude/skills`, Codex, Gemini CLI, Copilot CLI) auto-discovers it. The full content is preserved verbatim, prefaced by a short Overview + Checklist; "Don'ts" is renamed to "Anti-patterns" to match the convention used by sibling skills (writing-skills, etc.).

`AGENTS.md` becomes a short stub plus a four-bullet digest of the highest-frequency footguns (alias, `add -u`/`-f`, identity hook, `dotfiles pull` semantics), so tools that read project-root `AGENTS.md` but don't speak skills still degrade gracefully. `CLAUDE.md` is a symlink to `AGENTS.md` and follows automatically. The README callout now surfaces the skill path while keeping a fallback link to `AGENTS.md`.

## Why this is worth doing

- **Broader reach.** `AGENTS.md` at project root is only auto-loaded by tools that look for it there. Skills under `~/.agents/skills/` are user-scope and auto-discovered by every conformant CLI on every machine where this dotfiles repo is deployed.
- **On-demand load.** Full content fires only when the description matches (bare-repo cues, `dotfiles` alias, inverse-allowlist `.gitignore`, the `ajilty <github@ajilty.com>` identity hook, `dotfiles pull` rebase/autostash conflicts). Sessions that don't touch git in this repo don't pay the context cost.
- **Discoverable trigger.** The skill description front-loads tokens unlikely to collide with other skills, so when an agent sees `dotfiles add` warn about ignored paths or the pre-commit hook reject a commit, the skill fires.

## What changed

- `.agents/skills/dotfiles-repo/SKILL.md` (new, +125 lines)
- `AGENTS.md` (–105 net): replaced with stub + 4-bullet digest
- `README.md`: callout points at the skill, with `AGENTS.md` retained as fallback
- `CLAUDE.md` (symlink → `AGENTS.md`): follows automatically, no separate edit needed

## Test plan

- [ ] On a real bare-repo deployment: open a fresh Claude Code session in `$HOME`; ask a question that hits a documented footgun (e.g. "Why does `dotfiles add .claude/settings.json` warn that paths are ignored?") and confirm the `dotfiles-repo` skill is invoked.
- [ ] Verify `~/.claude/skills/dotfiles-repo/SKILL.md` resolves via the `~/.claude/skills → .agents/skills` symlink.
- [ ] Confirm `diff AGENTS.md CLAUDE.md` is empty after pull (symlink intact).
- [ ] Verify Codex / Gemini CLI / Copilot CLI also discover the skill (if available on the test machine).
- [ ] Confirm the README link `[.agents/skills/dotfiles-repo/SKILL.md]` renders on GitHub.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QxN7eziyVkXDSFZ8Cg3xvq)_