### PR TITLE
Patch prompt CI warmup to disable compaudit in sandbox .zshrc

### DIFF
--- a/.github/workflows/prompt.yml
+++ b/.github/workflows/prompt.yml
@@ -96,6 +96,18 @@ jobs:
           umask 022
           chmod -R go-w "$SANDBOX" 2>/dev/null || true
 
+          # CI runners can still make compaudit unhappy via parent directory
+          # permissions outside the sandbox. If compinit prompts during this
+          # non-interactive warmup, EOF answers abort and leaves zinit's
+          # deferred snippet resolver in a poisoned state. Patch only the
+          # disposable sandbox copy so CI skips compaudit without changing the
+          # checked-in interactive shell behavior.
+          perl -0pi -e 's/atload"zicompinit; zicdreplay"/atload"zicompinit -u; zicdreplay"/g' "$SANDBOX/.zshrc"
+          if ! grep -q 'zicompinit -u; zicdreplay' "$SANDBOX/.zshrc"; then
+            echo "failed to patch sandbox .zshrc for non-interactive compinit" >&2
+            exit 1
+          fi
+
           # PTY-backed warmup. Run interactive zsh under `script` (util-linux)
           # for 60s -- enough to let zinit's first-run install, deferred
           # `wait lucid` queue, compinit/zicdreplay, and p10k's gitstatusd


### PR DESCRIPTION
### Motivation

- Prevent non-interactive `compinit` prompts during the CI warmup from aborting and contaminating zinit state, which led to doubled snippet paths and missing completions. 
- Ensure the disposable sandbox copy of `~/.zshrc` used by the warmup skips the `compaudit` audit while preserving the checked-in interactive behavior.

### Description

- Update the prompt workflow (`.github/workflows/prompt.yml`) to patch the sandbox copy of `.zshrc` before the PTY-backed warmup by replacing `atload"zicompinit; zicdreplay"` with `atload"zicompinit -u; zicdreplay"` using a `perl -0pi -e` one-liner. 
- Add a verification guard that runs `grep -q 'zicompinit -u; zicdreplay'` against the sandbox `.zshrc` and fails the job early if the patch did not apply. 
- Leave the rest of the warmup (PTY-backed `script` run) unchanged so CI still exercises an interactive session for zinit/p10k first-run tasks.

### Testing

- Ran a static check that the workflow contains the `zicompinit -u` patch and the verification guard via `python3` assertions, which passed. 
- Verified the `perl` substitution logic against a sample `.zshrc` (local substitution check), which passed. 
- Performed shell syntax checks with `bash -n test/in-sandbox.sh test/run.sh test/tests.d/*.sh`, which passed. 
- Parsed the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/prompt.yml")'`, which succeeded. 
- Attempted to run the test suite (`DOTFILES_TEST_TIMEOUT_SECONDS=5 bash test/run.sh`), but it failed because `zsh` is not installed in this environment, and installing dependencies via `apt-get` also failed due to the environment's apt proxy returning HTTP 403, so full runtime verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0711df81f88327bf853c13e35a6614)